### PR TITLE
Timing shift

### DIFF
--- a/lib/Factories/MachineFactory.cpp
+++ b/lib/Factories/MachineFactory.cpp
@@ -16,7 +16,7 @@ MachineFactory::MachineFactory(const MachineConfig& config)
       _weightSensor(nullptr), 
       _taredWeight(&_dispatcher),
       _boilerTempProc(&_dispatcher),
-      _shotMonitorProc(&_dispatcher),
+      _shotMonitorProc(&_dispatcher, config.debounceMs / 1000.0f),
       _safetyProc(&_dispatcher),
       _wifi(nullptr),
       _ota(nullptr),
@@ -28,12 +28,12 @@ MachineFactory::MachineFactory(const MachineConfig& config)
     _themes = {&_defaultTheme, &_candyTheme, &_christmasTheme};
 
     // Register Hardware Sensors for central polling
+    _dispatcher.provide<SystemUptimeReading>(&_uptimeSensor);
     _dispatcher.provide<PumpReading>(&_pumpSensor);
     _dispatcher.provide<ButtonRightReading>(&_buttonRightSensor);
     _dispatcher.provide<ButtonLeftReading>(&_buttonLeftSensor);
     _dispatcher.provide<BoilerPressureReading>(&_boilerPressure);
     _dispatcher.provide<WeightReading>(&_weightSensor);
-    _dispatcher.provide<SystemUptimeReading>(&_uptimeSensor);
 
     // Attach Reactive Processors
     _dispatcher.attachProcessor<HeatingCycleReading>(&_heatingCycleProc);

--- a/lib/Factories/MachineFactory.cpp
+++ b/lib/Factories/MachineFactory.cpp
@@ -33,6 +33,7 @@ MachineFactory::MachineFactory(const MachineConfig& config)
     _dispatcher.provide<ButtonLeftReading>(&_buttonLeftSensor);
     _dispatcher.provide<BoilerPressureReading>(&_boilerPressure);
     _dispatcher.provide<WeightReading>(&_weightSensor);
+    _dispatcher.provide<SystemUptimeReading>(&_uptimeSensor);
 
     // Attach Reactive Processors
     _dispatcher.attachProcessor<HeatingCycleReading>(&_heatingCycleProc);

--- a/lib/Factories/MachineFactory.h
+++ b/lib/Factories/MachineFactory.h
@@ -8,6 +8,7 @@
 #include "../Sensors/Registry/RegistrySwitch.h"
 #include "../Sensors/Hardware/BoilerPressure.h"
 #include "../Sensors/Hardware/WeightSensor.h"
+#include "../Sensors/Hardware/SystemTimeSensor.h"
 #include "../Logic/Processors/TaredWeightProcessor.h"
 #include "../Logic/Processors/BoilerTemperatureProcessor.h"
 #include "../Logic/Processors/ShotMonitorProcessor.h"
@@ -82,6 +83,7 @@ private:
     WiFiService* _wifi;
     OTAService* _ota;
     WarmingUpBlocker* _warmingUpBlocker;
+    SystemTimeSensor _uptimeSensor;
     HeatingCycleProcessor _heatingCycleProc;
     WarmingUpProcessor _warmingUpProc;
 

--- a/lib/Interfaces/SensorTags.h
+++ b/lib/Interfaces/SensorTags.h
@@ -37,6 +37,7 @@ struct WiFiStatus;
 struct OTAStatus;
 struct WarmingUpStatus;
 struct BoilerSafetyStatus;
+struct SystemUptimeReading;
 
 /**
  * Logical Tags for the Sensor Registry.
@@ -49,6 +50,14 @@ struct HeatingCycleReading : public BaseTelemetryTag {
     using Children = TagList<struct WarmingUpStatus>;
     static SensorMetadata getMetadata() {
         return Units::Counter.range("CYCLES", 0.0f, 5.0f);
+    }
+};
+
+struct SystemUptimeReading : public BaseTelemetryTag {
+    static constexpr PhysicalQuantity QUANTITY = PhysicalQuantity::TIME;
+    static constexpr const char* NAME = "Uptime";
+    static SensorMetadata getMetadata() {
+        return Units::Time.range("UPTIME", 0.0f, 86400.0f); // 24h range for UI if needed
     }
 };
 

--- a/lib/Logic/Processors/ShotMonitorProcessor.cpp
+++ b/lib/Logic/Processors/ShotMonitorProcessor.cpp
@@ -3,7 +3,7 @@
 
 ShotMonitorProcessor::ShotMonitorProcessor(ISensorRegistry* registry)
     : _registry(registry), _pump(registry), 
-      _startTime(0), _isRunning(false), 
+      _startTimeSecs(0.0f), _isRunning(false), 
       _lastDuration(0.0f), _lastValidDuration(0.0f) {}
 
 void ShotMonitorProcessor::update() {
@@ -41,7 +41,7 @@ void ShotMonitorProcessor::update() {
 
 void ShotMonitorProcessor::startTimer() {
     _isRunning = true;
-    _startTime = millis();
+    _startTimeSecs = _registry->getLatest<SystemUptimeReading>().value;
     _lastDuration = 0.0f;
 }
 
@@ -53,5 +53,6 @@ void ShotMonitorProcessor::stopTimer() {
 
 float ShotMonitorProcessor::getElapsedSeconds() const {
     if (!_isRunning) return _lastDuration;
-    return (millis() - _startTime) / 1000.0f;
+    float now = _registry->getLatest<SystemUptimeReading>().value;
+    return now - _startTimeSecs;
 }

--- a/lib/Logic/Processors/ShotMonitorProcessor.cpp
+++ b/lib/Logic/Processors/ShotMonitorProcessor.cpp
@@ -1,8 +1,9 @@
 #include "ShotMonitorProcessor.h"
 #include <Arduino.h>
 
-ShotMonitorProcessor::ShotMonitorProcessor(ISensorRegistry* registry)
+ShotMonitorProcessor::ShotMonitorProcessor(ISensorRegistry* registry, float latencyCompSecs)
     : _registry(registry), _pump(registry), 
+      _latencyCompSecs(latencyCompSecs),
       _startTimeSecs(0.0f), _isRunning(false), 
       _lastDuration(0.0f), _lastValidDuration(0.0f) {}
 
@@ -21,7 +22,7 @@ void ShotMonitorProcessor::update() {
         
         // Filter purges (< 10s)
         if (duration >= 10.0f) {
-            _lastValidDuration = duration;
+            _lastValidDuration = _lastDuration; // Use compensated duration
         }
     }
 
@@ -47,7 +48,8 @@ void ShotMonitorProcessor::startTimer() {
 
 void ShotMonitorProcessor::stopTimer() {
     if (!_isRunning) return;
-    _lastDuration = getElapsedSeconds();
+    float duration = getElapsedSeconds();
+    _lastDuration = (duration > _latencyCompSecs) ? (duration - _latencyCompSecs) : 0.0f;
     _isRunning = false;
 }
 

--- a/lib/Logic/Processors/ShotMonitorProcessor.h
+++ b/lib/Logic/Processors/ShotMonitorProcessor.h
@@ -21,7 +21,7 @@ private:
     ISensorRegistry* _registry;
     RegistrySwitch<PumpReading> _pump;
     
-    unsigned long _startTime;
+    float _startTimeSecs;
     bool _isRunning;
     float _lastDuration;
     float _lastValidDuration;

--- a/lib/Logic/Processors/ShotMonitorProcessor.h
+++ b/lib/Logic/Processors/ShotMonitorProcessor.h
@@ -13,7 +13,7 @@
  */
 class ShotMonitorProcessor : public ITagProcessor {
 public:
-    ShotMonitorProcessor(ISensorRegistry* registry);
+    ShotMonitorProcessor(ISensorRegistry* registry, float latencyCompSecs = 0.0f);
     
     void update() override;
 
@@ -21,6 +21,7 @@ private:
     ISensorRegistry* _registry;
     RegistrySwitch<PumpReading> _pump;
     
+    float _latencyCompSecs;
     float _startTimeSecs;
     bool _isRunning;
     float _lastDuration;

--- a/lib/Logic/Processors/WarmingUpProcessor.cpp
+++ b/lib/Logic/Processors/WarmingUpProcessor.cpp
@@ -3,8 +3,9 @@
 #include <stdio.h>
 
 WarmingUpProcessor::WarmingUpProcessor(ISensorRegistry* registry, unsigned long timeoutMs)
-    : _registry(registry), _startTime(millis()), _timeoutMs(timeoutMs), _isFinished(false), _firstUpdate(true) {
+    : _registry(registry), _startTimeSecs(0.0f), _timeoutSecs(timeoutMs / 1000.0f), _isFinished(false), _firstUpdate(true) {
     if (_registry) {
+        _startTimeSecs = _registry->getLatest<SystemUptimeReading>().value;
         char valBuf[16];
         _registry->getLatest<BoilerPressureReading>().format(valBuf, sizeof(valBuf));
         snprintf(_statusBuffer, sizeof(_statusBuffer), "Heating Cycle 1, currently %s", valBuf);
@@ -17,6 +18,7 @@ void WarmingUpProcessor::update() {
 
     if (_firstUpdate) {
         _firstUpdate = false;
+        _startTimeSecs = _registry->getLatest<SystemUptimeReading>().value;
         Reading pressure = _registry->getLatest<BoilerPressureReading>();
         if (pressure.value > 0.1f) {
             _isFinished = true;
@@ -24,7 +26,8 @@ void WarmingUpProcessor::update() {
     }
 
     // 1. Timeout Check
-    if (!_isFinished && (millis() - _startTime >= _timeoutMs)) {
+    float now = _registry->getLatest<SystemUptimeReading>().value;
+    if (!_isFinished && (now - _startTimeSecs >= _timeoutSecs)) {
         _isFinished = true;
     }
 
@@ -60,8 +63,9 @@ float WarmingUpProcessor::getProgress() const {
     int currentCycles = (int)reading.value;
     float moveProgress = ((float)currentCycles / (float)TARGET_CYCLES) * 100.0f;
     
-    unsigned long elapsed = millis() - _startTime;
-    float timeProgress = (float)elapsed / (float)_timeoutMs * 100.0f;
+    float now = _registry->getLatest<SystemUptimeReading>().value;
+    float elapsed = now - _startTimeSecs;
+    float timeProgress = elapsed / _timeoutSecs * 100.0f;
     if (timeProgress > 100.0f) timeProgress = 100.0f;
     
     // Whichever is further along

--- a/lib/Logic/Processors/WarmingUpProcessor.h
+++ b/lib/Logic/Processors/WarmingUpProcessor.h
@@ -17,8 +17,8 @@ public:
 
 private:
     ISensorRegistry* _registry;
-    unsigned long _startTime;
-    unsigned long _timeoutMs;
+    float _startTimeSecs;
+    float _timeoutSecs;
     bool _isFinished;
     bool _firstUpdate;
     

--- a/lib/Logic/StartupLogic.cpp
+++ b/lib/Logic/StartupLogic.cpp
@@ -4,7 +4,7 @@
 
 StartupLogic::StartupLogic(ISwitchProvider* provider, ISensorRegistry* registry, unsigned long holdDurationMs) 
     : _wifiSwitch(registry), _otaSwitch(registry), _warmingUpSwitch(registry), _wifi(nullptr), _warmingUp(nullptr), _provider(provider), _registry(registry),
-      _state(State::SEARCHING_WIFI), _isActive(false), _justStarted(false), _justStopped(false), _lastActive(false), _startTime(0), _holdDurationMs(holdDurationMs) {}
+      _state(State::SEARCHING_WIFI), _isActive(false), _justStarted(false), _justStopped(false), _lastActive(false), _startTimeSecs(0.0f), _holdDurationSecs(holdDurationMs / 1000.0f) {}
 
 StatusMessage StartupLogic::getStatus() const {
     if (!_wifi) return StatusMessage("Startup", "INITIALIZING...", -1.0f, false);
@@ -50,7 +50,7 @@ void StartupLogic::update() {
     switch (_state) {
         case State::SEARCHING_WIFI:
             if (_wifiSwitch.isActive()) {
-                _startTime = millis();
+                _startTimeSecs = _registry->getLatest<SystemUptimeReading>().value;
                 _state = State::WIFI_STABLE;
             }
             break;
@@ -58,8 +58,8 @@ void StartupLogic::update() {
         case State::WIFI_STABLE:
             if (!_wifiSwitch.isActive()) {
                 _state = State::SEARCHING_WIFI;
-                _startTime = 0;
-            } else if (millis() - _startTime >= _holdDurationMs) {
+                _startTimeSecs = 0;
+            } else if (_registry->getLatest<SystemUptimeReading>().value - _startTimeSecs >= _holdDurationSecs) {
                 _provider->createOTA(); 
                 _state = State::OTA_STARTING;
             }

--- a/lib/Logic/StartupLogic.h
+++ b/lib/Logic/StartupLogic.h
@@ -44,8 +44,8 @@ private:
     bool _justStarted;
     bool _justStopped;
     bool _lastActive;
-    unsigned long _startTime;
-    unsigned long _holdDurationMs;
+    float _startTimeSecs;
+    float _holdDurationSecs;
 };
 
 #endif

--- a/lib/Sensors/Hardware/SystemTimeSensor.h
+++ b/lib/Sensors/Hardware/SystemTimeSensor.h
@@ -1,0 +1,20 @@
+#ifndef SYSTEM_TIME_SENSOR_H
+#define SYSTEM_TIME_SENSOR_H
+
+#include <Arduino.h>
+#include "../../Interfaces/HardwareSensor.h"
+
+/**
+ * A simple bridge sensor that provides system uptime in seconds.
+ * Does not require filtering or hysteresis as it's a monotonic counter.
+ */
+class SystemTimeSensor : public HardwareSensor {
+public:
+    SystemTimeSensor() : HardwareSensor(nullptr, 1.0f, 0.0f) {}
+
+    float getReading() override {
+        return millis() / 1000.0f;
+    }
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ MachineConfig config = {
   .otaHostname = OTA_HOSTNAME,
   .wifiSsid = WIFI_SSID,
   .wifiPassword = WIFI_PASSWORD,
-  .debounceMs = 150
+  .debounceMs = 30
 };
 
 MachineFactory factory(config);

--- a/test/_common/stubs/Arduino.cpp
+++ b/test/_common/stubs/Arduino.cpp
@@ -6,11 +6,11 @@ unsigned long millis() {
     return _mock_millis;
 }
 
-void setMillis(unsigned long ms) {
+void setHardwareTime(unsigned long ms) {
     _mock_millis = ms;
 }
 
-void addMillis(unsigned long ms) {
+void addHardwareTime(unsigned long ms) {
     _mock_millis += ms;
 }
 

--- a/test/_common/stubs/Arduino.h
+++ b/test/_common/stubs/Arduino.h
@@ -10,8 +10,8 @@ extern "C" {
 #endif
 
 unsigned long millis();
-void setMillis(unsigned long ms);
-void addMillis(unsigned long ms);
+void setHardwareTime(unsigned long ms);
+void addHardwareTime(unsigned long ms);
 void pinMode(int pin, int mode);
 int digitalRead(int pin);
 int analogRead(int pin);

--- a/test/test_calibration/test_calibration.cpp
+++ b/test/test_calibration/test_calibration.cpp
@@ -14,7 +14,7 @@ void test_pressure_scalar_application() {
     
     // 1.0 Bar baseline (ADC 806 -> 1.0 Bar with scalar 1.0)
     mock.setRawValue(806);
-    for(int i=0; i<100; i++) { setMillis(i); sensor.getReading(); }
+    for(int i=0; i<100; i++) { setHardwareTime(i); sensor.getReading(); }
     
     float rawExpected = 1.0f;
     float expectedValue = rawExpected * pressureScalar;
@@ -28,7 +28,7 @@ void test_pressure_scalar_1_25() {
     BoilerPressure sensor(&mock, 1.25f);
     
     mock.setRawValue(806); // 1.0 Bar raw
-    for(int i=0; i<100; i++) { setMillis(i); sensor.getReading(); }
+    for(int i=0; i<100; i++) { setHardwareTime(i); sensor.getReading(); }
     
     TEST_ASSERT_FLOAT_WITHIN(0.05f, 1.25f, sensor.getReading());
 }

--- a/test/test_digital_sensor/test_digital_sensor.cpp
+++ b/test/test_digital_sensor/test_digital_sensor.cpp
@@ -14,28 +14,28 @@ void test_digital_sensor_debounce() {
     // 50ms debounce
     DigitalSensor sensor(&source, true, 50);
 
-    setMillis(0);
+    setHardwareTime(0);
     source.val = LOW; // Raw Active
     
     // Immediately after change
     Reading r = sensor.getReading();
     TEST_ASSERT_FLOAT_WITHIN(0.1f, 0.0f, r.value); // Should still be inactive
     
-    setMillis(25);
+    setHardwareTime(25);
     r = sensor.getReading();
     TEST_ASSERT_FLOAT_WITHIN(0.1f, 0.0f, r.value); // Still inactive
 
-    setMillis(51);
+    setHardwareTime(51);
     r = sensor.getReading();
     TEST_ASSERT_FLOAT_WITHIN(0.1f, 1.0f, r.value); // Now active!
 
     // Noise: brief flip
     source.val = HIGH;
-    setMillis(60);
+    setHardwareTime(60);
     r = sensor.getReading();
     TEST_ASSERT_FLOAT_WITHIN(0.1f, 1.0f, r.value); // Should STAY active (filtered)
 
-    setMillis(111);
+    setHardwareTime(111);
     r = sensor.getReading();
     TEST_ASSERT_FLOAT_WITHIN(0.1f, 0.0f, r.value); // Now inactive after debounce
 }

--- a/test/test_filtering/test_filtering.cpp
+++ b/test/test_filtering/test_filtering.cpp
@@ -12,7 +12,7 @@ void test_pressure_rounding_jitter() {
     // 1. Settle just ABOVE a rounding boundary (1.16 Bar -> rounds to 1.2)
     // 1.16 Bar -> (1.16/1.25 + 0.5) = 1.428V sensor -> 0.714V pin -> (0.714/3.3)*4095 = 886 raw
     mock.setRawValue(886); 
-    for(int i=0; i<100; i++) { setMillis(i); pressure.getReading(); }
+    for(int i=0; i<100; i++) { setHardwareTime(i); pressure.getReading(); }
     
     float v1 = pressure.getReading();
     char buf1[16];
@@ -22,7 +22,7 @@ void test_pressure_rounding_jitter() {
     // 2. Small move (0.025 Bar) that triggers hysteresis and crosses boundary (1.135 Bar -> rounds to 1.1)
     // 1.135 Bar -> (1.135/1.25 + 0.5) = 1.408V sensor -> 0.704V pin -> (0.704/3.3)*4095 = 873 raw
     mock.setRawValue(873); 
-    for(int i=100; i<200; i++) { setMillis(i); pressure.getReading(); }
+    for(int i=100; i<200; i++) { setHardwareTime(i); pressure.getReading(); }
     
     float v2 = pressure.getReading();
     char buf2[16];
@@ -31,7 +31,7 @@ void test_pressure_rounding_jitter() {
 
     // 3. Move back UP by 0.021 Bar
     mock.setRawValue(896); 
-    for(int i=200; i<300; i++) { setMillis(i); pressure.getReading(); }
+    for(int i=200; i<300; i++) { setHardwareTime(i); pressure.getReading(); }
     
     float v3 = pressure.getReading();
     char buf3[16];

--- a/test/test_shot_processor/test_shot_processor.cpp
+++ b/test/test_shot_processor/test_shot_processor.cpp
@@ -15,20 +15,25 @@ void test_shot_timing() {
     registry.provide<PumpReading>(&pumpSensor);
     registry.attachProcessor<ShotTimeReading>(&processor);
 
-    setMillis(1000);
+    // Initial state
+    registry.publish<SystemUptimeReading>(1.0f);
+    registry.publish<PumpReading>(0.0f);
+    registry.update();
+
     // 1. Pump Start
     pumpSensor.setReading(1.0f); // ON
     registry.update();
 
-    setMillis(5000);
-    registry.update(); // 4 seconds later
+    // 4 seconds later (1s -> 5s)
+    registry.publish<SystemUptimeReading>(5.0f);
+    registry.update(); 
     
     Reading shotTime = registry.getLatest<ShotTimeReading>();
     TEST_ASSERT_FLOAT_WITHIN(0.1f, 4.0f, shotTime.value);
     TEST_ASSERT_EQUAL_STRING("RUNNING", shotTime.label);
 
     // 2. Pump Stop
-    setMillis(6000);
+    registry.publish<SystemUptimeReading>(6.0f);
     pumpSensor.setReading(0.0f); // OFF
     registry.update();
 
@@ -46,18 +51,20 @@ void test_last_valid_shot_filtering() {
     registry.attachProcessor<ShotTimeReading>(&processor);
 
     // 1. Long Shot (Valid)
-    setMillis(0);
+    registry.publish<SystemUptimeReading>(0.0f);
     pumpSensor.setReading(1.0f); registry.update();
-    setMillis(15000); // 15s
+    
+    registry.publish<SystemUptimeReading>(15.0f); // 15s
     pumpSensor.setReading(0.0f); registry.update();
 
     Reading lastValid = registry.getLatest<LastValidShotReading>();
     TEST_ASSERT_EQUAL_FLOAT(15.0f, lastValid.value);
 
     // 2. Short Shot (Purge - should be ignored)
-    setMillis(20000);
+    registry.publish<SystemUptimeReading>(20.0f);
     pumpSensor.setReading(1.0f); registry.update();
-    setMillis(25000); // 5s
+    
+    registry.publish<SystemUptimeReading>(25.0f); // 5s
     pumpSensor.setReading(0.0f); registry.update();
 
     lastValid = registry.getLatest<LastValidShotReading>();

--- a/test/test_shot_processor/test_shot_processor.cpp
+++ b/test/test_shot_processor/test_shot_processor.cpp
@@ -10,7 +10,7 @@
 void test_shot_timing() {
     SensorDispatcher registry;
     SensorStub pumpSensor;
-    ShotMonitorProcessor processor(&registry);
+    ShotMonitorProcessor processor(&registry, 0.1f); // 100ms compensation
 
     registry.provide<PumpReading>(&pumpSensor);
     registry.attachProcessor<ShotTimeReading>(&processor);
@@ -29,23 +29,23 @@ void test_shot_timing() {
     registry.update(); 
     
     Reading shotTime = registry.getLatest<ShotTimeReading>();
-    TEST_ASSERT_FLOAT_WITHIN(0.1f, 4.0f, shotTime.value);
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 4.0f, shotTime.value); // Running time not compensated
     TEST_ASSERT_EQUAL_STRING("RUNNING", shotTime.label);
 
     // 2. Pump Stop
-    registry.publish<SystemUptimeReading>(6.0f);
+    registry.publish<SystemUptimeReading>(6.0f); // 5s elapsed
     pumpSensor.setReading(0.0f); // OFF
     registry.update();
 
     shotTime = registry.getLatest<ShotTimeReading>();
-    TEST_ASSERT_EQUAL_FLOAT(5.0f, shotTime.value); // Final duration
+    TEST_ASSERT_EQUAL_FLOAT(4.9f, shotTime.value); // Final duration (5s - 0.1s)
     TEST_ASSERT_EQUAL_STRING("READY", shotTime.label);
 }
 
 void test_last_valid_shot_filtering() {
     SensorDispatcher registry;
     SensorStub pumpSensor;
-    ShotMonitorProcessor processor(&registry);
+    ShotMonitorProcessor processor(&registry, 0.1f); // 100ms compensation
 
     registry.provide<PumpReading>(&pumpSensor);
     registry.attachProcessor<ShotTimeReading>(&processor);
@@ -58,7 +58,7 @@ void test_last_valid_shot_filtering() {
     pumpSensor.setReading(0.0f); registry.update();
 
     Reading lastValid = registry.getLatest<LastValidShotReading>();
-    TEST_ASSERT_EQUAL_FLOAT(15.0f, lastValid.value);
+    TEST_ASSERT_EQUAL_FLOAT(14.9f, lastValid.value); // 15s - 0.1s
 
     // 2. Short Shot (Purge - should be ignored)
     registry.publish<SystemUptimeReading>(20.0f);
@@ -68,7 +68,7 @@ void test_last_valid_shot_filtering() {
     pumpSensor.setReading(0.0f); registry.update();
 
     lastValid = registry.getLatest<LastValidShotReading>();
-    TEST_ASSERT_EQUAL_FLOAT(15.0f, lastValid.value); // Still 15s!
+    TEST_ASSERT_EQUAL_FLOAT(14.9f, lastValid.value); // Still 14.9s!
 }
 
 int main() {

--- a/test/test_startup_logic/test_startup.cpp
+++ b/test/test_startup_logic/test_startup.cpp
@@ -27,6 +27,9 @@ void test_startup_factory_coordination() {
     TEST_ASSERT_FALSE(logic.isActive());
     TEST_ASSERT_FALSE(factory.otaCreated());
     
+    // Initial uptime
+    registry.publish<SystemUptimeReading>(0.0f);
+
     // 1. Initial State: SEARCHING_WIFI
     registry.update(); // Initial poll
     logic.update(); 
@@ -34,14 +37,14 @@ void test_startup_factory_coordination() {
     
     // 2. Connect WiFi
     WiFi.setStatus(WL_CONNECTED);
-    setMillis(100); 
+    registry.publish<SystemUptimeReading>(0.1f); // 100ms
     wifi.update();     // Publishes WiFiStatus=1.0 to registry
     registry.update(); // Updates cache
     logic.update();    // Sees WiFiStatus=1.0 via RegistrySwitch
     TEST_ASSERT_FALSE(factory.otaCreated());
 
     // 3. Hold wait (3s) -> Transitions to OTA_STARTING
-    setMillis(3100); 
+    registry.publish<SystemUptimeReading>(3.1f); 
     wifi.update(); 
     registry.update();
     logic.update();
@@ -50,7 +53,6 @@ void test_startup_factory_coordination() {
     TEST_ASSERT_FALSE(logic.isActive()); 
 
     // 4. OTA Ready (Listening) -> Transitions to WARMING_UP state
-    // Manual publish to mock OTA service publishing its state
     registry.publish<OTAStatus>(StatusMessage("OTA", "ON", 100.0f, false));
     warmingUp.setTitle("Warming Up...");
     registry.update();
@@ -77,29 +79,27 @@ void test_startup_transition_loop_timing() {
     MachineProviderStub factory(&wifi, &ota, &warmingUp);
     StartupLogic logic(&factory, &registry);
 
-    printf("\nDEBUG: Started Loop Timing Test\n"); fflush(stdout);
-
     // Initial state: SEARCHING_WIFI
-    setMillis(0);
+    registry.publish<SystemUptimeReading>(0.0f);
     registry.update();
     logic.update(); 
     TEST_ASSERT_FALSE(logic.justStarted());
 
     // 1. Progress to WARMING_UP
     // Frame 1: SEARCHING -> WIFI_STABLE
-    setMillis(100); 
+    registry.publish<SystemUptimeReading>(0.1f);
     wifi.update(); 
     registry.update();
     logic.update(); 
     
     // Frame 2: Wait in WIFI_STABLE
-    setMillis(2000); 
+    registry.publish<SystemUptimeReading>(2.0f);
     wifi.update();
     registry.update();
     logic.update();
     
     // Frame 3: WIFI_STABLE -> OTA_STARTING (after 3000ms from Frame 1)
-    setMillis(3200); 
+    registry.publish<SystemUptimeReading>(3.2f);
     wifi.update();
     registry.update();
     logic.update();
@@ -137,9 +137,9 @@ void test_double_update_edge_loss_warning() {
     StartupLogic logic(&factory, &registry);
 
     // 1. Advance to READY frame
-    setMillis(0); registry.update(); logic.update();
-    setMillis(100); wifi.update(); registry.update(); logic.update(); // WIFI_STABLE
-    setMillis(3200); wifi.update(); registry.update(); logic.update(); // OTA_STARTING
+    registry.publish<SystemUptimeReading>(0.0f); registry.update(); logic.update();
+    registry.publish<SystemUptimeReading>(0.1f); wifi.update(); registry.update(); logic.update(); // WIFI_STABLE
+    registry.publish<SystemUptimeReading>(3.2f); wifi.update(); registry.update(); logic.update(); // OTA_STARTING
     registry.publish<OTAStatus>(StatusMessage("OTA", "ON", 100.0f, false));
     registry.update(); logic.update();                                // WARMING_UP
     
@@ -149,15 +149,6 @@ void test_double_update_edge_loss_warning() {
     logic.update(); 
     TEST_ASSERT_TRUE(logic.justStarted()); 
 
-    // 3. Second update in same loop (This represents the BUG we fixed)
-    // In the new architecture, logic.update() uses RegistrySwitch::update().
-    // If RegistrySwitch::update() is called again in the same frame, 
-    // it will pull CURRENT reading and compare against ITS PREVIOUS frame state.
-    
-    // BUT wait: RegistrySwitch::update() sets _lastIsActive = _isActive.
-    // So a second update() in the SAME frame WILL consume the edge!
-    // This is correct behavior for the switch - it's the Orchestrator's responsibility 
-    // to call update() only once per frame.
     logic.update();
     
     // 4. Verification: Edge is correctly "lost" (processed) by the second update

--- a/test/test_warming_up/test_warming_up.cpp
+++ b/test/test_warming_up/test_warming_up.cpp
@@ -93,7 +93,6 @@ void test_warm_startup_reactive() {
 }
 
 void test_timeout() {
-    setMillis(0);
     SensorDispatcher registry;
     SensorStub pressureSensor;
     WarmingUpBlocker blocker(&registry);
@@ -103,13 +102,22 @@ void test_timeout() {
     registry.attachProcessor<HeatingCycleReading>(&cycleProc);
     registry.attachProcessor<WarmingUpStatus>(&processor);
     
+    // Initial uptime and pressure (cold)
+    registry.publish<SystemUptimeReading>(0.0f);
+    registry.publish<BoilerPressureReading>(0.0f);
+
+    registry.update(); // Clear firstUpdate flag if it exists (processor might check it)
     blocker.update();
     TEST_ASSERT_FALSE(blocker.isActive());
 
-    setMillis(600000);
-    // Trigger update to check timeout
-    registry.publish<BoilerPressureReading>(0.5f);
+    // Travel to 10 minutes (600 seconds)
+    registry.publish<SystemUptimeReading>(600.0f);
+
+    // Trigger update (without pressure skip)
+    registry.publish<BoilerPressureReading>(0.05f); // Still below 0.1f skip threshold
     blocker.update();
+    
+    // This should FAIL (RED) until WarmingUpProcessor is refactored to use SystemUptimeReading
     TEST_ASSERT_TRUE(blocker.isActive());
 }
 


### PR DESCRIPTION
We now record the system time in the registry and base all tests off that rather than hardware time.

This isolates the tests better and gives a better abstraction from the hardware, where we were using a shim to hoodwink the logic tests with a millis() call in the unit tests.

That code is still used with some of the hardware sensor tests but called something more sensible.

Also attempted to fix a timing issue with the shot timer, where the time on screen didn't feel like the right one. Tweaks to the debounce and a correction in the timing "looks" better but might need to be reviewed at a later time.